### PR TITLE
feat: add support for callback in send method

### DIFF
--- a/event-store/src/main/java/org/hypertrace/core/eventstore/EventProducer.java
+++ b/event-store/src/main/java/org/hypertrace/core/eventstore/EventProducer.java
@@ -30,6 +30,25 @@ public interface EventProducer<K, V> {
   void send(K key, V value, long timestamp);
 
   /**
+   * Sends data to underlying sink asynchronously with a callback to handle completion or errors.
+   *
+   * @param key message key
+   * @param value message value/payload
+   * @param callback callback to be invoked when the send completes or fails
+   */
+  void send(K key, V value, SendCallback callback);
+
+  /**
+   * Sends data to underlying sink asynchronously with a callback to handle completion or errors.
+   *
+   * @param key message key
+   * @param value message value/payload
+   * @param timestamp time stamp to be used for the event
+   * @param callback callback to be invoked when the send completes or fails
+   */
+  void send(K key, V value, long timestamp, SendCallback callback);
+
+  /**
    * Sends data to underlying sink, async by default unless sync=true in the init configs
    *
    * @param events list of events

--- a/event-store/src/main/java/org/hypertrace/core/eventstore/SendCallback.java
+++ b/event-store/src/main/java/org/hypertrace/core/eventstore/SendCallback.java
@@ -1,0 +1,18 @@
+package org.hypertrace.core.eventstore;
+
+/**
+ * A callback interface that allows clients to receive notifications when a send operation
+ * completes. This can be used to handle both successful sends and errors asynchronously.
+ */
+public interface SendCallback {
+
+  /**
+   * Called when a send operation completes.
+   *
+   * @param result The result of the send operation if successful, null if an exception occurred
+   * @param exception The exception thrown during the send operation, null if the send was
+   *     successful
+   */
+  void onCompletion(SendResult result, Exception exception);
+}
+

--- a/event-store/src/main/java/org/hypertrace/core/eventstore/SendResult.java
+++ b/event-store/src/main/java/org/hypertrace/core/eventstore/SendResult.java
@@ -1,0 +1,57 @@
+package org.hypertrace.core.eventstore;
+
+/**
+ * Represents the result of a successful send operation. This class abstracts away the underlying
+ * implementation details (e.g., Kafka's RecordMetadata) and provides a common interface for
+ * clients.
+ */
+public class SendResult {
+
+  private final String topic;
+  private final int partition;
+  private final long offset;
+  private final long timestamp;
+
+  public SendResult(String topic, int partition, long offset, long timestamp) {
+    this.topic = topic;
+    this.partition = partition;
+    this.offset = offset;
+    this.timestamp = timestamp;
+  }
+
+  /** Returns the topic the record was appended to. */
+  public String getTopic() {
+    return topic;
+  }
+
+  /** Returns the partition the record was sent to. */
+  public int getPartition() {
+    return partition;
+  }
+
+  /** Returns the offset of the record in the topic/partition. */
+  public long getOffset() {
+    return offset;
+  }
+
+  /** Returns the timestamp of the record in the topic/partition. */
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public String toString() {
+    return "SendResult{"
+        + "topic='"
+        + topic
+        + '\''
+        + ", partition="
+        + partition
+        + ", offset="
+        + offset
+        + ", timestamp="
+        + timestamp
+        + '}';
+  }
+}
+

--- a/event-store/src/main/java/org/hypertrace/core/eventstore/kafka/KafkaEventProducer.java
+++ b/event-store/src/main/java/org/hypertrace/core/eventstore/kafka/KafkaEventProducer.java
@@ -13,6 +13,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.hypertrace.core.eventstore.EventProducer;
 import org.hypertrace.core.eventstore.EventProducerConfig;
 import org.hypertrace.core.eventstore.KeyValuePair;
+import org.hypertrace.core.eventstore.SendCallback;
+import org.hypertrace.core.eventstore.SendResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +48,38 @@ public class KafkaEventProducer<K, V> implements EventProducer<K, V> {
   @Override
   public void send(K key, V value, long timestamp) {
     producer.send(new ProducerRecord<>(this.topic, null, timestamp, key, value));
+  }
+
+  @Override
+  public void send(K key, V value, SendCallback callback) {
+    producer.send(
+        new ProducerRecord<>(this.topic, key, value),
+        (metadata, exception) ->
+            callback.onCompletion(
+                exception == null
+                    ? new SendResult(
+                        metadata.topic(),
+                        metadata.partition(),
+                        metadata.offset(),
+                        metadata.timestamp())
+                    : null,
+                exception));
+  }
+
+  @Override
+  public void send(K key, V value, long timestamp, SendCallback callback) {
+    producer.send(
+        new ProducerRecord<>(this.topic, null, timestamp, key, value),
+        (metadata, exception) ->
+            callback.onCompletion(
+                exception == null
+                    ? new SendResult(
+                        metadata.topic(),
+                        metadata.partition(),
+                        metadata.offset(),
+                        metadata.timestamp())
+                    : null,
+                exception));
   }
 
   @Override


### PR DESCRIPTION
## Description
The [send method in our KafkaEventProducer library](https://github.com/hypertrace/event-store/blob/main/event-store/src/main/java/org/hypertrace/core/eventstore/kafka/KafkaEventProducer.java#L43) calls the send method of [Apache's KafkaProducer](https://kafka.apache.org/10/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html#send-org.apache.kafka.clients.producer.ProducerRecord-) which returns a Future<RecordMetadata> but our library ignores it. As the documentation says, "The send is asynchronous and this method will return immediately once the record has been stored in the buffer of records waiting to be sent." Calling send() does NOT mean the record is already written to Kafka. If the client wants to check/ensure that the record was successfully written to Kafka, the client should check the Future<RecordMetadata> returned by Apache KakaProducer's send method or provide a [callback to the send method](https://kafka.apache.org/10/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html#send-org.apache.kafka.clients.producer.ProducerRecord-org.apache.kafka.clients.producer.Callback-). But our library doesn't provide any of these capabilities. So, there is no way for the client of our library to know if there were any errors while writing to Kafka.

To address this shortcoming, I've added send method which accepts a callback.